### PR TITLE
Add FlyPloy to AI Tools section

### DIFF
--- a/docs/AI_tools.md
+++ b/docs/AI_tools.md
@@ -9,6 +9,7 @@
 
 ### 代码生成
 
+- [FlyPloy](https://flyploy.com/en) - 简单强大的现代化应用部署平台，支持 Docker 和 Kubernetes，助力开发者实现全球一键快速部署。
 - [Copilot](https://github.com/features/copilot)  
 - [Codeium](https://codeium.com/)  
 - [Replit](https://replit.com/)


### PR DESCRIPTION
FlyPloy is an AI-native PaaS platform designed to help tech novices and developers deploy AI projects instantly.

Website: https://flyploy.com/en