### PR TITLE
docs: 收录 Seedream AI Studio 到 AI 绘画/图像工具

### DIFF
--- a/docs/AI_tools.md
+++ b/docs/AI_tools.md
@@ -30,6 +30,7 @@
 - [Ideogram](https://ideogram.ai) — 擅长在图像中精准生成文字与排版的 AI 绘画工具。
 - [Adobe Firefly](https://www.adobe.com/products/firefly.html) — Adobe 的创意生成式 AI，版权安全、深度集成创意套件。
 - [即梦 Dreamina](https://jimeng.jianying.com) — 字节跳动剪映团队的国产 AI 图像与视频创作平台。
+- [Seedream AI Studio](https://seedream4.video) — 基于字节跳动 Seedream 5.0/4.5/4.0 模型的多模型 AI 图像生成平台，支持一键调用可灵 2.1 进行图生视频动画，有免费额度。
 - [文心一格](https://yige.baidu.com) — 百度的 AI 艺术创作平台，支持多种风格、对新手友好。
 
 ### AI 视频生成


### PR DESCRIPTION
## 新增工具

将 [Seedream AI Studio](https://seedream4.video) 收录到 `docs/AI_tools.md` 的 **AI 绘画/图像** 板块。

## 工具介绍

Seedream AI Studio 是基于字节跳动 Seedream 5.0/4.5/4.0 模型的多模型 AI 图像生成平台，支持在同一界面对比不同模型的生成结果，并可一键调用可灵 Kling 2.1 将图像转为短视频动画。免费额度可用，适合创作者快速出图并制作动态内容。

与已收录的「即梦 Dreamina」形成互补：即梦是字节官方平台，Seedream AI Studio 是独立整合了 Seedream 系列模型的第三方创作工具，提供多模型横向对比功能。