### PR TITLE
添加 Tura 到命令行编码 Agent

### DIFF
--- a/docs/Coding_Agents.md
+++ b/docs/Coding_Agents.md
@@ -29,6 +29,7 @@
 | Omnigent | [GitHub](https://github.com/omnigent-ai/omnigent) | 开源 AI Agent 框架与"元 harness"（Python，Apache-2.0），可统一编排 Claude Code、Codex、Cursor、pi 及自定义 Agent，无需改写即可热插拔 harness，并提供策略管控、沙箱与跨设备实时协作 |
 | ruflo | [GitHub](https://github.com/ruvnet/ruflo) | 面向 Claude 的开源 Agent"元 harness"（TypeScript，MIT），可部署多智能体群（swarm）、编排自主工作流，内置自适应记忆、自学习群体智能与 RAG 集成，原生对接 Claude Code / Codex |
 | DeepSeek-Reasonix | [GitHub](https://github.com/esengine/DeepSeek-Reasonix) | DeepSeek 原生的终端 AI 编码 Agent（Go，MIT），围绕前缀缓存（prefix-cache）稳定性设计，适合长时间常驻运行 |
+| Tura | [GitHub](https://github.com/Tura-AI/tura) ・[官网](https://turaai.net/) ・[基准](https://turaai.net/benchmark) | 本地开源编码 Agent（AGPL-3.0），提供 CLI、TUI、GUI，支持仓库编辑、命令执行、验证与任务级上下文管理，并公开长周期任务的可复现基准产物 |
 
 ## IDE / 编辑器编码 Agent
 

--- a/docs/Coding_Agents.md
+++ b/docs/Coding_Agents.md
@@ -29,7 +29,7 @@
 | Omnigent | [GitHub](https://github.com/omnigent-ai/omnigent) | 开源 AI Agent 框架与"元 harness"（Python，Apache-2.0），可统一编排 Claude Code、Codex、Cursor、pi 及自定义 Agent，无需改写即可热插拔 harness，并提供策略管控、沙箱与跨设备实时协作 |
 | ruflo | [GitHub](https://github.com/ruvnet/ruflo) | 面向 Claude 的开源 Agent"元 harness"（TypeScript，MIT），可部署多智能体群（swarm）、编排自主工作流，内置自适应记忆、自学习群体智能与 RAG 集成，原生对接 Claude Code / Codex |
 | DeepSeek-Reasonix | [GitHub](https://github.com/esengine/DeepSeek-Reasonix) | DeepSeek 原生的终端 AI 编码 Agent（Go，MIT），围绕前缀缓存（prefix-cache）稳定性设计，适合长时间常驻运行 |
-| Tura | [GitHub](https://github.com/Tura-AI/tura) ・[官网](https://turaai.net/) ・[基准](https://turaai.net/benchmark) | 本地开源编码 Agent（AGPL-3.0），提供 CLI、TUI、GUI，支持仓库编辑、命令执行、验证与任务级上下文管理，并公开长周期任务的可复现基准产物 |
+| Tura | [GitHub](https://github.com/Tura-AI/tura) ・[官网](https://turaai.net/) ・[基准](https://turaai.net/benchmark) | Tura 是一个本地开源编码 Agent，面向厌倦了含糊技能宣传、缺乏证据的 token-saving 扩展，以及尚未理解仓库便开始修改的 Agent 的开发者。 |
 
 ## IDE / 编辑器编码 Agent
 


### PR DESCRIPTION
## Tura: 16.7% better performance, 77.5% fewer rounds.

Tura 是一个本地开源编码 Agent，面向厌倦了含糊技能宣传、缺乏证据的 token-saving 扩展，以及尚未理解仓库便开始修改的 Agent 的开发者。

本 PR 在 `docs/Coding_Agents.md` 的“命令行 / 终端编码 Agent”表格末尾增加一条简洁、可核验的中文条目。

- GitHub：https://github.com/Tura-AI/tura
- 官网：https://turaai.net/
- 基准与原始产物：https://turaai.net/benchmark
- 许可证：AGPL-3.0-or-later

披露：我是 Tura 项目的关联贡献者，本次提交用于将该项目加入与其范围直接匹配的开源编码 Agent 列表。

AI 协助披露：本次条目和 PR 文案在 AI 协助下整理，并由我根据 Tura 根 README 与本仓库内容逐项核验。