### PR TITLE
Add ClawBench to browser agent benchmarks

### DIFF
--- a/docs/Browser_Computer_Use.md
+++ b/docs/Browser_Computer_Use.md
@@ -136,6 +136,7 @@
 | WebArena | [GitHub](https://github.com/web-arena-x/webarena) | 可自托管的真实网站仿真环境，评测自主网页 Agent（含多模态扩展 VisualWebArena） |
 | WebVoyager | [GitHub](https://github.com/MinorJerry/WebVoyager) | 基于多模态大模型的网页 Agent 与基准，含 15 个真实网站、600+ 任务 |
 | Mind2Web | [GitHub](https://github.com/OSU-NLP-Group/Mind2Web) | 首个通用网页 Agent 基准，覆盖 137 个网站、31 个领域、2000+ 任务 |
+| ClawBench | [GitHub](https://github.com/TIGER-AI-Lab/ClawBench) | 面向真实在线任务的浏览器 Agent 基准，V1/V2 共 283 个任务；隔离运行并记录视频、截图、HTTP 流量、浏览器动作与 Agent 消息，便于端到端评测和失败分析 |
 | OSWorld | [GitHub](https://github.com/xlang-ai/OSWorld) | 真实计算机环境中评测多模态 Agent 的开放式桌面任务基准 |
 | AndroidWorld | [GitHub](https://github.com/google-research/android_world) | 运行在真实 Android 模拟器上的移动端 Agent 基准 |
 | GAIA | [链接](https://huggingface.co/datasets/gaia-benchmark/GAIA) | 通用 AI 助手基准（含网页浏览任务），466 题分 3 个难度等级 |


### PR DESCRIPTION
## Summary

- add ClawBench to the browser and computer-use benchmark table
- note its 283 live-site tasks, isolated runs, and five-layer execution evidence

## Validation

- `git diff --check`
- verified the GitHub link returns HTTP 200

## Disclosure

I am a ClawBench maintainer and am submitting this project directly.

This pull request was prepared with assistance from OpenAI Codex. I reviewed and verified the final change.